### PR TITLE
Fix Bug - the DefaultUserProvider should match the DefaultDriver

### DIFF
--- a/src/Illuminate/Auth/CreatesUserProviders.php
+++ b/src/Illuminate/Auth/CreatesUserProviders.php
@@ -89,6 +89,6 @@ trait CreatesUserProviders
      */
     public function getDefaultUserProvider()
     {
-        return $this->app['config']['auth.defaults.provider'];
+        return $this->app['config']['auth.guards.'.$this->getDefaultDriver().'.provider'];
     }
 }


### PR DESCRIPTION
I foud this bug when trying to set `Auth::shouldUse($name)` in middleware.  In my controller, `Auth::getDefaultDriver()` would always return `'web'` which was the default in `App\Config\Auth.php`.  A `dd()` of Config::get('auth') cinfirmed that the config value had in fact been changed, but `Auth:;getDefaultDriver()` was still returning the default value. 

The problem is a bug in the `'CreatesUsersProviders'` trait.

```
public function getDefaultUserProvider()
    {
        return $this->app['config']['auth.defaults.provider'];
    }
```
There are two problems here.  First, `'auth.defaults.provider'` is not defined in the default configuration when creating a new Laravel app.  So, this will always return null causing all UserProviders to be created using the default.  Second, even if it is added to the config file, the default user provider should not be hardcoded.  It should be the provider used by the default guard.  So, it should be changed to:

`return $this->app['config']['auth.guards.' . $this->getDefaultDriver() . '.provider'];`